### PR TITLE
Factor out dorms by year

### DIFF
--- a/site/_data/dorms_by_year.json
+++ b/site/_data/dorms_by_year.json
@@ -1,0 +1,102 @@
+{
+  "freshman": [
+    {
+      "dorm_id": "barton-hall",
+      "dorm_name": "Barton Hall"
+    },
+    {
+      "dorm_id": "bray-hall",
+      "dorm_name": "Bray Hall"
+    },
+    {
+      "dorm_id": "burdett-avenue-residence-hall",
+      "dorm_name": "Burdett Avenue Residence Hall"
+    },
+    {
+      "dorm_id": "cary-hall",
+      "dorm_name": "Cary Hall"
+    },
+    {
+      "dorm_id": "crockett-hall",
+      "dorm_name": "Crockett Hall"
+    },
+    {
+      "dorm_id": "davison-hall",
+      "dorm_name": "Davison Hall"
+    },
+    {
+      "dorm_id": "hall-hall",
+      "dorm_name": "Hall Hall"
+    },
+    {
+      "dorm_id": "nason-hall",
+      "dorm_name": "Nason Hall"
+    },
+    {
+      "dorm_id": "nugent-hall",
+      "dorm_name": "Nugent Hall"
+    },
+    {
+      "dorm_id": "sharp-hall",
+      "dorm_name": "Sharp Hall"
+    },
+    {
+      "dorm_id": "warren-hall",
+      "dorm_name": "Warren Hall"
+    }
+  ],
+  "sophomore": [
+    {
+      "dorm_id": "beman-and-brinsmade",
+      "dorm_name": "Beman and Brinsmade"
+    },
+    {
+      "dorm_id": "blitman-residence-commons",
+      "dorm_name": "Blitman Residence Commons"
+    },
+    {
+      "dorm_id": "colonie-apartments",
+      "dorm_name": "Colonie Apartments"
+    },
+    {
+      "dorm_id": "colvin-and-albright",
+      "dorm_name": "Colvin and Albright"
+    },
+    {
+      "dorm_id": "e-complex",
+      "dorm_name": "E-Complex"
+    },
+    {
+      "dorm_id": "north-hall",
+      "dorm_name": "North Hall"
+    },
+    {
+      "dorm_id": "quadrangle",
+      "dorm_name": "Quadrangle"
+    },
+    {
+      "dorm_id": "stackwyck-apartments",
+      "dorm_name": "Stackwyck Apartments"
+    }
+  ],
+  "junior": [
+    {
+      "dorm_id": "bryckwyck-apartments",
+      "dorm_name": "Bryckwyck Apartments"
+    },
+    {
+      "dorm_id": "city-station-south",
+      "dorm_name": "City Station South"
+    },
+    {
+      "dorm_id": "polytechnic-apartments",
+      "dorm_name": "Polytechnic Apartments"
+    }
+  ],
+  "senior": [
+    {
+      "dorm_id": "city-station-west",
+      "dorm_name": "City Station West"
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -14,17 +14,9 @@ layout: default
           Freshman
         </h3>
         <div class="fs-5 fw-light">
-          <a href="/dorms/barton-hall" class="dorm-link">Barton Hall</a>
-          <a href="/dorms/bray-hall" class="dorm-link">Bray Hall</a>
-          <a href="/dorms/burdett-avenue-residence-hall" class="dorm-link">Burdett Avenue Residence Hall</a>
-          <a href="/dorms/cary-hall" class="dorm-link">Cary Hall</a>
-          <a href="/dorms/crockett-hall" class="dorm-link">Crockett Hall</a>
-          <a href="/dorms/davison-hall" class="dorm-link">Davison Hall</a>
-          <a href="/dorms/hall-hall" class="dorm-link">Hall Hall</a>
-          <a href="/dorms/nason-hall" class="dorm-link">Nason Hall</a>
-          <a href="/dorms/nugent-hall" class="dorm-link">Nugent Hall</a>
-          <a href="/dorms/sharp-hall" class="dorm-link">Sharp Hall</a>
-          <a href="/dorms/warren-hall" class="dorm-link">Warren Hall</a>
+          {% for freshman_dorm in site.data.dorms_by_year["freshman"] %}
+              <a href="/dorms/{{ freshman_dorm.dorm_id }}" class="dorm-link">{{ freshman_dorm.dorm_name }}</a>
+          {% endfor %}
         </div>
       </div>
       <div class="col-lg">
@@ -32,14 +24,9 @@ layout: default
           Sophomore
         </h3>
         <div class="fs-5 fw-light">
-          <a href="/dorms/beman-and-brinsmade" class="dorm-link">Beman and Brinsmade</a>
-          <a href="/dorms/blitman-residence-commons" class="dorm-link">Blitman Residence Commons</a>
-          <a href="/dorms/colonie-apartments" class="dorm-link">Colonie Apartments</a>
-          <a href="/dorms/colvin-and-albright" class="dorm-link">Colvin and Albright</a>
-          <a href="/dorms/e-complex" class="dorm-link">E-Complex</a>
-          <a href="/dorms/north-hall" class="dorm-link">North Hall</a>
-          <a href="/dorms/quadrangle" class="dorm-link">Quadrangle</a>
-          <a href="/dorms/stackwyck-apartments" class="dorm-link">Stackwyck Apartments</a>
+          {% for sophomore_dorm in site.data.dorms_by_year["sophomore"] %}
+              <a href="/dorms/{{ sophomore_dorm.dorm_id }}" class="dorm-link">{{ sophomore_dorm.dorm_name }}</a>
+          {% endfor %}
         </div>
       </div>
     </div>
@@ -49,9 +36,9 @@ layout: default
           Junior
         </h3>
         <div class="fs-5 fw-light">
-          <a href="/dorms/bryckwyck-apartments" class="dorm-link">Bryckwyck Apartments</a>
-          <a href="/dorms/city-station-south" class="dorm-link">City Station South</a>
-          <a href="/dorms/polytechnic-apartments" class="dorm-link">Polytechnic Apartments</a>
+          {% for junior_dorm in site.data.dorms_by_year["junior"] %}
+              <a href="/dorms/{{ junior_dorm.dorm_id }}" class="dorm-link">{{ junior_dorm.dorm_name }}</a>
+          {% endfor %}
         </div>
       </div>
       <div class="col-lg">
@@ -59,7 +46,9 @@ layout: default
           Senior/Co-term
         </h3>
         <div class="fs-5 fw-light">
-          <a href="/dorms/city-station-west" class="dorm-link">City Station West</a>
+          {% for senior_dorm in site.data.dorms_by_year["senior"] %}
+              <a href="/dorms/{{ senior_dorm.dorm_id }}" class="dorm-link">{{ senior_dorm.dorm_name }}</a>
+          {% endfor %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Removes hardcoded elements in the home page of the dorm sorting by year, such that the json file can be autogenerated every term.